### PR TITLE
reorder progress bar components

### DIFF
--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -71,10 +71,10 @@ def create_progress_bar():
         spinner = random.choice(('aesthetic', 'arc', 'bounce', 'dots', 'line', 'monkey', 'point', 'simpleDots'))
 
         progress_bar = Progress(
-            TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total})"),
-            BarColumn(bar_width=None),
-            "[progress.percentage]{task.percentage:>3.1f}%",
             SpinnerColumn(spinner),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total} done)"),
+            BarColumn(bar_width=None),
             TimeElapsedColumn(),
             transient=True,
             expand=True,


### PR DESCRIPTION
@branfosj For https://github.com/easybuilders/easybuild-framework/pull/3826, to avoid pushing too much stuff to the right.

This makes the progress bar look something like this:

```
... 64.7% Installing CMake/3.18.4 (1/2 done) ━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━ 0:00:13
```