### PR TITLE
tweak GPU part of output produced by --show-system-info

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1318,11 +1318,6 @@ class EasyBuildOptions(GeneralOption):
             "  -> speed: %s" % system_info['cpu_speed'],
             "  -> cores: %s" % system_info['core_count'],
             "  -> features: %s" % ','.join(cpu_features),
-            '',
-            "* software:",
-            "  -> glibc version: %s" % system_info['glibc_version'],
-            "  -> Python binary: %s" % sys.executable,
-            "  -> Python version: %s" % sys.version.split(' ')[0],
         ])
 
         if gpu_info:
@@ -1333,7 +1328,15 @@ class EasyBuildOptions(GeneralOption):
             for vendor in gpu_info:
                 lines.append("  -> %s" % vendor)
                 for gpu, num in gpu_info[vendor].items():
-                    lines.append("    -> %s: %s" % (gpu, num))
+                    lines.append("    -> %sx %s" % (num, gpu))
+
+        lines.extend([
+            '',
+            "* software:",
+            "  -> glibc version: %s" % system_info['glibc_version'],
+            "  -> Python binary: %s" % sys.executable,
+            "  -> Python version: %s" % sys.version.split(' ')[0],
+        ])
 
         return '\n'.join(lines)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -592,7 +592,7 @@ def get_gpu_info():
                     nvidia_gpu_info.setdefault(line, 0)
                     nvidia_gpu_info[line] += 1
             else:
-                _log.debug("None zero exit (%s) from nvidia-smi: %s" % (ec, out))
+                _log.debug("None zero exit (%s) from nvidia-smi: %s", ec, out)
         except Exception as err:
             _log.debug("Exception was raised when running nvidia-smi: %s", err)
             _log.info("No NVIDIA GPUs detected")


### PR DESCRIPTION
@branfosj Two minor changes for `--show-system-info` output in https://github.com/easybuilders/easybuild-framework/pull/3851:

* Also use `1x NVIDIA ...` output, like in test report comments
* Show `GPU` section right below `CPU` section, above `software` section

Also consistently used [lazy logging](https://medium.com/swlh/why-it-matters-how-you-log-in-python-1a1085851205) in `get_gpu_info` function