### PR TITLE
use log.deprecated in py2vs3 module

### DIFF
--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -23,8 +23,14 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from easybuild.base import fancylogger
+
 # all functionality provided by the py3 modules is made available via the easybuild.tools.py2vs3 namespace
 from easybuild.tools.py2vs3.py3 import *  # noqa
+
+
+_log = fancylogger.getLogger('py2vs3', fname=False)
+_log.deprecated("Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.", '6.0')
 
 
 # based on six's 'with_metaclass' function

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -62,12 +62,6 @@ except ImportError:
 # string type that can be used in 'isinstance' calls
 string_type = str
 
-warning_lines = [
-    "Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.",
-    "This module will be removed in a future EasyBuild Version.",
-]
-sys.stderr.write('\n\n' + '\n'.join(warning_lines) + '\n\n\n')
-
 
 def json_loads(body):
     """Wrapper for json.loads that takes into account that Python versions older than 3.6 require a string value."""


### PR DESCRIPTION
@branfosj for https://github.com/easybuilders/easybuild-framework/pull/4229

This yields a better warning message, which will automatically turn into an error message with EasyBuild >= 6.0:

```
$ eb Perl.eb -D
WARNING: Deprecated functionality, will no longer work in v6.0: Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.; see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information
```

```
$ eb Perl.eb --deprecated 6.0
ERROR: Failed to process easyconfig /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/p/Perl/Perl-5.36.0-GCCcore-12.2.0.eb: DEPRECATED (since v6.0) functionality used: Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.; see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information
```

I'll open a separate framework PR to fix the outdated link to the docs (although the current link still works, it gets auto-redirected to https://docs.easybuild.io/deprecated-functionality)