### PR TITLE
relocate subprocess_popen_text + subprocess_terminate to easybuild.tools.run, import create_base_metaclass + mk_wrapper_baseclass from easybuild.base.wrapper in py2vs3/*.py

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -48,7 +48,7 @@ from optparse import SUPPRESS_HELP as nohelp  # supported in optparse of python 
 
 from easybuild.base.fancylogger import getLogger, setroot, setLogLevel, getDetailsLogLevels
 from easybuild.base.optcomplete import autocomplete, CompleterOption
-from easybuild.tools.asyncprocess import subprocess_popen_text
+from easybuild.tools.run import subprocess_popen_text
 from easybuild.tools.utilities import mk_md_table, mk_rst_table, nub, shell_quote
 
 try:

--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -152,24 +152,6 @@ class Popen(subprocess.Popen):
 message = "Other end disconnected!"
 
 
-def subprocess_popen_text(cmd, **kwargs):
-    """Call subprocess.Popen in text mode with specified named arguments."""
-    # open stdout/stderr in text mode in Popen when using Python 3
-    kwargs.setdefault('stderr', subprocess.PIPE)
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)
-
-
-def subprocess_terminate(proc, timeout):
-    """Terminate the subprocess if it hasn't finished after the given timeout"""
-    try:
-        proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        for pipe in (proc.stdout, proc.stderr, proc.stdin):
-            if pipe:
-                pipe.close()
-        proc.terminate()
-
-
 def recv_some(p, t=.2, e=1, tr=5, stderr=0):
     if tr < 1:
         tr = 1

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -43,7 +43,6 @@ import shlex
 
 from easybuild.base import fancylogger
 from easybuild.tools import StrictVersion
-from easybuild.tools.asyncprocess import subprocess_popen_text
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import ERROR, IGNORE, PURGE, UNLOAD, UNSET
 from easybuild.tools.config import EBROOT_ENV_VAR_ACTIONS, LOADED_MODULES_ACTIONS
@@ -51,7 +50,7 @@ from easybuild.tools.config import build_option, get_modules_tool, install_path
 from easybuild.tools.environment import ORIG_OS_ENVIRON, restore_env, setvar, unset_env_vars
 from easybuild.tools.filetools import convert_name, mkdir, normalize_path, path_matches, read_file, which, write_file
 from easybuild.tools.module_naming_scheme.mns import DEVEL_MODULE_SUFFIX
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_cmd, subprocess_popen_text
 from easybuild.tools.utilities import get_subclasses, nub
 
 # software root/version environment variable name prefixes

--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -22,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 #
+import sys
 
 from easybuild.base import fancylogger
 
@@ -33,3 +34,26 @@ from easybuild.tools.py2vs3.py3 import *  # noqa
 
 _log = fancylogger.getLogger('py2vs3', fname=False)
 _log.deprecated("Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.", '6.0')
+
+
+def python2_is_deprecated():
+    """
+    Print warning when using Python 2, since the support for running EasyBuild with it is deprecated.
+    """
+    if sys.version_info[0] == 2:
+        full_py_ver = '.'.join(str(x) for x in sys.version_info[:3])
+        warning_lines = [
+            "Running EasyBuild with Python v2.x is deprecated, found Python v%s." % full_py_ver,
+            "Support for running EasyBuild with Python v2.x will be removed in EasyBuild v5.0.",
+            '',
+            "It is strongly recommended to start using Python v3.x for running EasyBuild,",
+            "see https://docs.easybuild.io/en/latest/Python-2-3-compatibility.html for more information.",
+        ]
+        max_len = max(len(x) for x in warning_lines)
+        for i in range(len(warning_lines)):
+            line_len = len(warning_lines[i])
+            warning_lines[i] = '!!! ' + warning_lines[i] + ' ' * (max_len - line_len) + ' !!!'
+        max_len = max(len(x) for x in warning_lines)
+        warning_lines.insert(0, '!' * max_len)
+        warning_lines.append('!' * max_len)
+        sys.stderr.write('\n\n' + '\n'.join(warning_lines) + '\n\n\n')

--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -25,7 +25,7 @@
 
 from easybuild.base import fancylogger
 
-from easybuild.base.wrapper import create_base_metaclass
+from easybuild.base.wrapper import create_base_metaclass  # noqa
 
 # all functionality provided by the py3 modules is made available via the easybuild.tools.py2vs3 namespace
 from easybuild.tools.py2vs3.py3 import *  # noqa

--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -25,16 +25,11 @@
 
 from easybuild.base import fancylogger
 
+from easybuild.base.wrapper import create_base_metaclass
+
 # all functionality provided by the py3 modules is made available via the easybuild.tools.py2vs3 namespace
 from easybuild.tools.py2vs3.py3 import *  # noqa
 
 
 _log = fancylogger.getLogger('py2vs3', fname=False)
 _log.deprecated("Using py2vs3 is deprecated, since EasyBuild no longer runs on Python 2.", '6.0')
-
-
-# based on six's 'with_metaclass' function
-# see also https://stackoverflow.com/questions/18513821/python-metaclass-understanding-the-with-metaclass
-def create_base_metaclass(base_class_name, metaclass, *bases):
-    """Create new class with specified metaclass based on specified base class(es)."""
-    return metaclass(base_class_name, bases, {})

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -59,6 +59,8 @@ try:
 except ImportError:
     HAVE_DISTUTILS = False
 
+from easybuild.tools.run import subprocess_popen_text, subprocess_terminate
+
 # string type that can be used in 'isinstance' calls
 string_type = str
 
@@ -73,24 +75,6 @@ def json_loads(body):
         body = body.decode('utf-8', 'ignore')
 
     return json.loads(body)
-
-
-def subprocess_popen_text(cmd, **kwargs):
-    """Call subprocess.Popen in text mode with specified named arguments."""
-    # open stdout/stderr in text mode in Popen when using Python 3
-    kwargs.setdefault('stderr', subprocess.PIPE)
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)
-
-
-def subprocess_terminate(proc, timeout):
-    """Terminate the subprocess if it hasn't finished after the given timeout"""
-    try:
-        proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        for pipe in (proc.stdout, proc.stderr, proc.stdin):
-            if pipe:
-                pipe.close()
-        proc.terminate()
 
 
 def raise_with_traceback(exception_class, message, traceback):

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -34,7 +34,6 @@ Authors:
 # these are not used here, but imported from here in other places
 import configparser  # noqa
 import json
-import subprocess
 import sys
 import urllib.request as std_urllib  # noqa
 from collections import OrderedDict  # noqa
@@ -59,8 +58,8 @@ try:
 except ImportError:
     HAVE_DISTUTILS = False
 
-from easybuild.base.wrapper import mk_wrapper_baseclass
-from easybuild.tools.run import subprocess_popen_text, subprocess_terminate
+from easybuild.base.wrapper import mk_wrapper_baseclass  # noqa
+from easybuild.tools.run import subprocess_popen_text, subprocess_terminate  # noqa
 
 # string type that can be used in 'isinstance' calls
 string_type = str

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -59,6 +59,7 @@ try:
 except ImportError:
     HAVE_DISTUTILS = False
 
+from easybuild.base.wrapper import mk_wrapper_baseclass
 from easybuild.tools.run import subprocess_popen_text, subprocess_terminate
 
 # string type that can be used in 'isinstance' calls
@@ -85,17 +86,6 @@ def raise_with_traceback(exception_class, message, traceback):
 def extract_method_name(method_func):
     """Extract method name from lambda function."""
     return '_'.join(method_func.__code__.co_names)
-
-
-def mk_wrapper_baseclass(metaclass):
-
-    class WrapperBase(object, metaclass=metaclass):
-        """
-        Wrapper class that provides proxy access to an instance of some internal instance.
-        """
-        __wraps__ = None
-
-    return WrapperBase
 
 
 def safe_cmp_looseversions(v1, v2):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -769,3 +769,21 @@ def check_log_for_errors(log_txt, reg_exps):
     if errors:
         raise EasyBuildError("Found %s error(s) in command output (output: %s)",
                              len(errors), "\n\t".join(errors))
+
+
+def subprocess_popen_text(cmd, **kwargs):
+    """Call subprocess.Popen in text mode with specified named arguments."""
+    # open stdout/stderr in text mode in Popen when using Python 3
+    kwargs.setdefault('stderr', subprocess.PIPE)
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)
+
+
+def subprocess_terminate(proc, timeout):
+    """Terminate the subprocess if it hasn't finished after the given timeout"""
+    try:
+        proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        for pipe in (proc.stdout, proc.stderr, proc.stdin):
+            if pipe:
+                pipe.close()
+        proc.terminate()

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -45,7 +45,7 @@ import warnings
 from collections import OrderedDict
 from ctypes.util import find_library
 from socket import gethostname
-from easybuild.tools.asyncprocess import subprocess_popen_text
+from easybuild.tools.run import subprocess_popen_text
 
 # pkg_resources is provided by the setuptools Python package,
 # which we really want to keep as an *optional* dependency

--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -34,7 +34,8 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
 import easybuild.tools.asyncprocess as p
-from easybuild.tools.asyncprocess import Popen, subprocess_terminate
+from easybuild.tools.asyncprocess import Popen
+from easybuild.tools.run import subprocess_terminate
 
 
 class AsyncProcessTest(EnhancedTestCase):

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -46,11 +46,10 @@ from easybuild.base.fancylogger import setLogLevelDebug
 
 import easybuild.tools.asyncprocess as asyncprocess
 import easybuild.tools.utilities
-from easybuild.tools.asyncprocess import subprocess_terminate
 from easybuild.tools.build_log import EasyBuildError, init_logging, stop_logging
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
 from easybuild.tools.run import check_async_cmd, check_log_for_errors, complete_cmd, get_output_from_process
-from easybuild.tools.run import parse_log_for_error, run_cmd, run_cmd_qa
+from easybuild.tools.run import parse_log_for_error, run_cmd, run_cmd_qa, subprocess_terminate
 from easybuild.tools.config import ERROR, IGNORE, WARN
 
 


### PR DESCRIPTION
@branfosj for https://github.com/easybuilders/easybuild-framework/pull/4229

`easybuild.tools.asyncprocess` is 3rd party code (which we maybe can even ditch if we only need to support for Python >= 3.6), so I think it's better to add the `subprocess_popen_text` and `subprocess_terminate` to `easybuild.tools.run` instead (and to avoid still having a copy in `py2vs3/py3`, we can also there import them from `easybuild.tools.run`)

