### PR TITLE
improve error message on version mismatch when using `--from-pr` + rename `UNKNOWN_VERSION` to `UNKNOWN_EASYBLOCKS_VERSION`

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -83,7 +83,8 @@ from easybuild.tools.py2vs3 import python2_is_deprecated
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.systemtools import check_easybuild_deps
 from easybuild.tools.testing import create_test_report, overall_test_report, regtest, session_state
-from easybuild.tools.version import EASYBLOCKS_VERSION, FRAMEWORK_VERSION, UNKNOWN_VERSION, different_major_versions
+from easybuild.tools.version import EASYBLOCKS_VERSION, FRAMEWORK_VERSION, UNKNOWN_EASYBLOCKS_VERSION
+from easybuild.tools.version import different_major_versions
 
 
 _log = None
@@ -620,7 +621,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None, pr
      from_pr_list, tweaked_ecs_paths) = cfg_settings
 
     # compare running Framework and EasyBlocks versions
-    if EASYBLOCKS_VERSION == UNKNOWN_VERSION:
+    if EASYBLOCKS_VERSION == UNKNOWN_EASYBLOCKS_VERSION:
         # most likely reason is running framework unit tests with no easyblocks installation
         # so log a warning, to avoid test related issues
         _log.warning("Unable to determine EasyBlocks version, so we'll assume it is not different from Framework")

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -594,8 +594,8 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_account=None, gi
         ver = _get_version_for_repo(os.path.join(final_path, 'easybuild', 'easyblocks', '__init__.py'))
 
     if different_major_versions(FRAMEWORK_VERSION, ver):
-        raise EasyBuildError("Framework (%s) is a different major version than PR target (%s)." % (FRAMEWORK_VERSION,
-                                                                                                   ver))
+        raise EasyBuildError("Framework (%s) is a different major version than used in %s/%s PR #%s (%s)",
+                             FRAMEWORK_VERSION, github_account, github_repo, pr, ver)
 
     return files
 

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -47,7 +47,7 @@ from socket import gethostname
 # This causes problems further up the dependency chain...
 VERSION = LooseVersion('4.9.2.dev0')
 UNKNOWN = 'UNKNOWN'
-UNKNOWN_VERSION = '0.0.UNKNOWN.EASYBLOCKS'
+UNKNOWN_EASYBLOCKS_VERSION = '0.0.UNKNOWN.EASYBLOCKS'
 
 
 def get_git_revision():
@@ -88,7 +88,7 @@ FRAMEWORK_VERSION = VERBOSE_VERSION
 try:
     from easybuild.easyblocks import VERBOSE_VERSION as EASYBLOCKS_VERSION
 except Exception:
-    EASYBLOCKS_VERSION = UNKNOWN_VERSION  # make sure it is smaller then anything
+    EASYBLOCKS_VERSION = UNKNOWN_EASYBLOCKS_VERSION  # make sure it is smaller then anything
 
 
 def this_is_easybuild():


### PR DESCRIPTION
@branfosj for https://github.com/easybuilders/easybuild-framework/pull/4520